### PR TITLE
feat+refactor: add structs for blocks, track-address and refactor commands and cli parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "either",
  "futures-util",
  "log",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -158,6 +160,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fastrand"
@@ -631,6 +639,20 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "either",
  "futures-util",
  "log",
  "serde",
@@ -160,12 +159,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fastrand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 log = { version = "0.4" }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0" }
-either = { version = "1.5.0"}
 tokio = { version = "1.0.0", features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time"] }
 tokio-tungstenite = { version = "0.17.1", features = ["connect", "native-tls"]}
 url = { version = "2.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ anyhow = { version = "1.0" }
 clap = { version = "3.0", features = ["derive"]}
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 log = { version = "0.4" }
-serde_json = "1.0"
+serde = { version = "1.0.117", features = ["derive"] }
+serde_json = { version = "1.0" }
+either = { version = "1.5.0"}
 tokio = { version = "1.0.0", features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time"] }
 tokio-tungstenite = { version = "0.17.1", features = ["connect", "native-tls"]}
 url = { version = "2.0.0" }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,44 @@
-# A CLI block explorer for mempool.space websocket
+# A terminal block explorer for mempool.space websocket
 
-This is an initial approach in building a cli interface for consuming and streaming blocks, transactions and mempool statistics from [mempool.space websocket API](https://mempool.space/docs/api/websocket).
+A terminal block explorer exposing the features available on mempool.space websocket API [mempool.space websocket API](https://mempool.space/docs/api/websocket).
 
-## Executing - WIP
+Currently available features are:
+- All data feed from mempool.space for: blocks, mempool-blocks, live-2h-chart, and stats.
+- Subscription for address related data: track-address.
 
-And you can execute the code with the following command:
+## How to use:
 
-``` sh
-cargo run
-```
-
-Or for testnet:
+To use this CLI you must have rust and cargo installed in your computer, you can check it wih:
 
 ``` sh
-cargo run -- --endpoint mempool.space/testnet/api
+rustc --version
 ```
 
+``` sh
+cargo --version
+```
+
+If you have cargo and rust installed, you can run the following commands:
+
+``` sh
+# mainnet connection is default
+cargo run -- track-address <your-btc-address>
+
+# to use testnet
+cargo run -- track-address <your-btc-address> --endpoint mempool.space/testnet/api
+```
+
+``` sh
+# all feed [blocks, mempool-blocks, live-2h-chart, and stats] for mainnet:
+cargo run -- blocks-data
+
+# or all feed [blocks, mempool-blocks, live-2h-chart, and stats] for testnet:
+cargo run -- --endpoint mempool.space/testnet/api blocks-data
+```
+
+## Compiling and using:
+To compile and use it as a command in terminal with no need of cargo, you can use the following command:
+
+``` sh
+cargo install --path .
+```


### PR DESCRIPTION
This PR adds:
- structs for track-address and block-data data to build messages
- refactor cli parsing to use commands and subcommands
- adds track-address feature from mempool.api WS api